### PR TITLE
fix: Add host and port to Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn main:app
+web: uvicorn main:app --host 0.0.0.0 --port $PORT


### PR DESCRIPTION
Configure the server to listen on host `0.0.0.0` and the port defined by the environment variable `$PORT`